### PR TITLE
Fixing documentation on how to add a host entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Dm tries to make it easier to do docker development on your mac. This means:
     - Makes ~/ a docker volume so you can easily bind project files to containers
 - Giving you an easy way to use hostnames with your containers
     - add env var VIRTUAL_HOST to your docker compose
-    - run `dm hosts add myhostname.dev`
+    - run `dm hosts add --host=myhostname.dev`
 - Lots more
     - run `dm` to see all the base commands
     - run `dm {command_name} -h` to see all available subcommands and help


### PR DESCRIPTION
Seems you've slightly changed the API (converted from a single parameter to `add` to multiple flags?), as `dm hosts add myhostname.dev` yields `--host cannot be blank`. I changed the docs, the working command seems to be `dm hosts add --host=myhostname.dev` (that's also what the documentation states, see `dm hosts --help`.